### PR TITLE
Rewrite chain standardization 

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,3 @@
+# Default ignored files
+/shelf/
+/workspace.xml

--- a/.idea/PDBClean-0.0.2.iml
+++ b/.idea/PDBClean-0.0.2.iml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="PYTHON_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+  <component name="PyDocumentationSettings">
+    <option name="format" value="PLAIN" />
+    <option name="myDocStringFormat" value="Plain" />
+  </component>
+</module>

--- a/.idea/inspectionProfiles/profiles_settings.xml
+++ b/.idea/inspectionProfiles/profiles_settings.xml
@@ -1,0 +1,6 @@
+<component name="InspectionProjectProfileManager">
+  <settings>
+    <option name="USE_PROJECT_PROFILE" value="false" />
+    <version value="1.0" />
+  </settings>
+</component>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/PDBClean-0.0.2.iml" filepath="$PROJECT_DIR$/.idea/PDBClean-0.0.2.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/environment.yml
+++ b/environment.yml
@@ -180,6 +180,7 @@ dependencies:
   - zlib=1.2.12=hfe4f2af_2
   - zstd=1.5.2=ha9df2e0_2
   - pip:
+    - matching==1.4
     - pip==22.1.2
     - pyqt5-sip==12.11.0
 prefix: ~/anaconda3/envs/PDBCleanV2

--- a/scripts/PDBClean_ChainStandardization_CIF.py
+++ b/scripts/PDBClean_ChainStandardization_CIF.py
@@ -31,20 +31,16 @@ Standard_Sequences = {}
 ############################################
 input_menu = ""
 input_menu_check_1 = ""
-input_menu_check_2 = ""
 
 while(input_menu != "QUIT"):
     print("PDBClean ChainID Standardization Menu",
           "    Select one of the following options to proceed:",
-          "    1) Select Standard Sequences from input structure",
-          "    2) Create Standard Sequences from consensus of input structures",
+          "    1) Select Standard Sequences from a chosen input structure",
+          "    2) Generate Standard Sequences based on all the input structures",
           sep="\n")
     if(input_menu_check_1 == "1"):
         print("    3) Inspect/Edit Standard Sequences",
-              "    4) Perform pairwise alignments against Standard Sequences",
-              sep="\n")
-    if(input_menu_check_2 == "1"):
-        print("    5) Perform Standardization of Chain IDs",
+              "    4) Perform Standardization of Chain IDs",
               sep="\n")
     input_menu = input('Option Number: ')
     if (input_menu == "1"):
@@ -57,14 +53,16 @@ while(input_menu != "QUIT"):
                                                                                              Standard_Sequences,
                                                                                              chid_list,
                                                                                              input_menu_check_1)
+        print("These are the standard sequences:")
+        print(Standard_Sequences)
     elif (input_menu == "3" and input_menu_check_1 == "1"):
         chainstd.review_standard_seq(Structure_Sequences, Standard_Sequences)
-    elif (input_menu == "4" and input_menu_check_1 == "1"):
-        ChainReassignmentMapping_List, ChainReassignmentScores_List, input_menu_check_2 = chainstd.align_to_standard_seq(Structure_Sequences,
-                                                                                                                         Standard_Sequences,
-                                                                                                                         structid_list)
-    elif (input_menu == "5" and input_menu_check_2 == "1"):
-        chainstd.reassignedmaps_to_pdb(filelist, ChainReassignmentMapping_List, structid_list, target_dir=target_dir)
-        chainstd.reassignedmaps_to_log(ChainReassignmentMapping_List, ChainReassignmentScores_List, structid_list, target_dir=target_dir)
+
+    elif (input_menu == "4" and input_menu_check_1=="1"):
+        chainstd.align_to_std_seq_and_save_to_disk(Structure_Sequences,
+                                                   Standard_Sequences,
+                                                   structid_list,
+                                                   filelist,
+                                                   target_dir=target_dir)
         print("Done!")
         input_menu="QUIT"

--- a/src/alignmentutils.py
+++ b/src/alignmentutils.py
@@ -45,17 +45,19 @@ def AlignSequences(sequence_vec):
             newfafile.write("> Seq" + "\n")
             newfafile.write(seq + "\n")
 
-    os.popen('muscle -align Seq.fa -output Seq.afa')
+    process=os.popen('muscle -align Seq.fa -output Seq.afa')
 
-    time.sleep(2) #FAPA
+    process
+
+    time.sleep(1) #FAPA
 
     #FAPA START
     while not os.path.exists("Seq.afa"):
-        time.sleep(10)
+        time.sleep(1) #FAPA, WAITING LESS TIME
         print("waiting...")
 
     while not os.path.getsize("Seq.afa") >= os.path.getsize("Seq.fa"):
-        time.sleep(10)
+        time.sleep(1) #FAPA, WAITING LESS TIME
         print("waiting even more...")
 
     #FAPA ENDS
@@ -71,6 +73,8 @@ def AlignSequences(sequence_vec):
             else:
                 seq += line.strip()
         aligned_seq.append(seq)
+
+    process.close()
     return (aligned_seq)
 # END AlignSequences
 


### PR DESCRIPTION
The previous version of chain standardization was not usable in practice. Thus we rewrote the way to compare chains to a reference structure. We use a matching library, so we also need to update the YML file. Also fixed some minor bugs in alignments.py 