### PR TITLE
Fixed syntax by adding spaces between variable

### DIFF
--- a/scripts/PDBClean_ChainStandardization_CIF.py
+++ b/scripts/PDBClean_ChainStandardization_CIF.py
@@ -65,4 +65,4 @@ while(input_menu != "QUIT"):
                                                    filelist,
                                                    target_dir=target_dir)
         print("Done!")
-        input_menu="QUIT"
+        input_menu = "QUIT"

--- a/scripts/PDBClean_MolID_CIF.py
+++ b/scripts/PDBClean_MolID_CIF.py
@@ -20,8 +20,8 @@ n_arg = len(sys.argv)
 if(n_arg<3):
     print('Usage error: {0} <source directory> <target directory>'.format(sys.argv[0]))
     sys.exit()
-source_dir=sys.argv[1]
-target_dir=sys.argv[2]
+source_dir = sys.argv[1]
+target_dir = sys.argv[2]
 
 
 #########################################

--- a/src/pdbclean_io.py
+++ b/src/pdbclean_io.py
@@ -8,7 +8,7 @@ def check_project(projdir=None, level='top', action='create', verbose=True):
     if projdir is None:
         print("Please provide a project directory path")
     else:
-        dirname=projdir
+        dirname = projdir
         if(level!='top'):
             dirname=dirname+'/'+level
         if(action=='create'):

--- a/src/pdbcleanchainstandardizationutils.py
+++ b/src/pdbcleanchainstandardizationutils.py
@@ -147,7 +147,7 @@ def review_standard_seq(Structure_Sequences, Standard_Sequences):
             if input_submenu in Standard_Sequences:
                 print(Standard_Sequences[input_submenu])
         elif (input_submenu == "3"):
-            chid= input('Chain ID: ')
+            chid = input('Chain ID: ')
             this_chainsseq_list, this_chainsseq_score = get_this_chainsseq_list(Structure_Sequences, chid, verbose=True)
 
 def align_to_std_seq_and_save_to_disk(Structure_Sequences, Standard_Sequences, structid_list, filelist, target_dir):
@@ -155,7 +155,7 @@ def align_to_std_seq_and_save_to_disk(Structure_Sequences, Standard_Sequences, s
     align_to_standard_seq and save new files to disk
     """
     ignore_chid = []
-    input_submenu= ""
+    input_submenu = ""
     input_submenu_4_check_1 = ""
     while(input_submenu != "QUIT"):
         print("    Perform pairwise alignments against Standard Sequences. Type QUIT to return to the main menu.",
@@ -209,7 +209,7 @@ def align_to_std_seq_and_save_to_disk(Structure_Sequences, Standard_Sequences, s
                 print(filelist2)
                 print("this is chid_seq_map and length")
                 print(chid_seq_map)
-                chid_seq_map_len=len(chid_seq_map)
+                chid_seq_map_len = len(chid_seq_map)
                 print(chid_seq_map_len)
                 Struct_ChainReassignmentMap = {}
                 Struct_ChainReassignmentScores = {}
@@ -264,7 +264,7 @@ def align_to_std_seq_and_save_to_disk(Structure_Sequences, Standard_Sequences, s
 
 
                     #if std_chid not in ignore_chid: # we don't want to have any of the ignored chains 0_0
-                        test_list_list[std_chid]= structchid_score_map
+                        test_list_list[std_chid] = structchid_score_map
 
                         #print("test_list_list:")
                         #print(test_list_list)
@@ -316,10 +316,10 @@ def align_to_std_seq_and_save_to_disk(Structure_Sequences, Standard_Sequences, s
 
                 capacities={}
                 for h in list(test_list_list_sortkey2.keys()):
-                    capacities[h]=1
+                    capacities[h] = 1
 
                 game = HospitalResident.create_from_dictionaries(test_list_list_sortkey2, test_list_list_T_sortkey, capacities)
-                solved_game=game.solve()
+                solved_game = game.solve()
 
                 output = {}
                 for k in solved_game.keys():
@@ -370,7 +370,7 @@ def align_to_standard_seq(Structure_Sequences, Standard_Sequences, structid_list
     align_to_standard_seq
     """
     ignore_chid = []
-    input_submenu= ""
+    input_submenu = ""
     input_submenu_4_check_1 = ""
     while(input_submenu != "QUIT"):
         print("    Perform pairwise alignments against Standard Sequences. Type QUIT to return to the main menu.",
@@ -478,7 +478,7 @@ def align_to_standard_seq(Structure_Sequences, Standard_Sequences, structid_list
                 # Now for final check, make sure no conflicts by checking unused chid
                 # Loop over all chid in the structure
                 unused_chid = []
-                free_chid=[] #FAPA
+                free_chid = [] #FAPA
                 for chid in chid_seq_map:
                     if chid not in Struct_ChainReassignmentMap.keys():
                         unused_chid.append(chid)

--- a/src/pdbcleanmolidcifutils.py
+++ b/src/pdbcleanmolidcifutils.py
@@ -54,7 +54,7 @@ def update_masterlist(master_molID_class_list, molIDConversion_list):
         molID_class.check_for_concatenations()
     return master_molID_class_list
 
-# The class containing all the information about each file neccessary to build
+# The class containing all the information about each file necessary to build
 # a conversion template
 class MolID(object):
         # file_name = ""


### PR DESCRIPTION
some inconsistencies were corrected such as, 

input_menu="QUIT" --> input_menu = "QUIT"
and 
source_dir=sys.argv[1] --> source_dir = sys.argv[1]