### PR TITLE
Updated writing entity category

### DIFF
--- a/src/cleanutils.py
+++ b/src/cleanutils.py
@@ -179,16 +179,22 @@ def simplify_cif(oldfile, newfile, pdbformat):
             newciffile.write("'" + L1 + "' " + L2 + " " + "\n")
 
         # Writes Entity category
+        # PAULINA 05/08/26
         newciffile.write("#" + "\n")
         newciffile.write("loop_" + "\n")
         newciffile.write("_entity.id" + "\n")
+        newciffile.write("_entity.type" + "\n")
+        newciffile.write("_entity.src_method" + "\n")
         newciffile.write("_entity.pdbx_description" + "\n")
         L1 = mmcif_dict['_entity.id']
-        L2 = mmcif_dict['_entity.pdbx_description']
-        for i in range(len(L1)):
-            L2[i] = L2[i].upper()
-            L2[i] = L2[i].replace(":", "")
-            newciffile.write(L1[i] + " '" + L2[i].replace("'", "") + "'\n")
+        n = len(L1)
+        L2 = mmcif_dict.get('_entity.type', ['polymer'] * n)
+        L3 = mmcif_dict.get('_entity.src_method', ['?'] * n)
+        L4 = mmcif_dict['_entity.pdbx_description']
+        for i in range(n):
+            L4[i] = L4[i].upper()
+            L4[i] = L4[i].replace(":", "")
+            newciffile.write(L1[i] + " " + L2[i] + " " + L3[i] + " '" + L4[i].replace("'", "") + "'\n")
 
         # Writes the coordinate portion of the file
         newciffile.write("#" + "\n")


### PR DESCRIPTION
fixed issue #202 

I updated the writing entity category to include "_entity.type" and "_entity.src_method".

 I also added a safety guard where if entity type does not exist, the missing values will get replaced with "polymer", and for missing source methods the default value is "?".